### PR TITLE
Add optional launch-template and --state filters to hosts

### DIFF
--- a/cmd/hosts.go
+++ b/cmd/hosts.go
@@ -95,10 +95,10 @@ func showHosts(hosts []*ec2.Instance) {
 
 // nolint: gochecknoglobals
 var hostsCmd = &cobra.Command{
-	Use:   "hosts account",
-	Short: "List EC2 instances.",
+	Use:   "hosts account [template-name]",
+	Short: "List EC2 instances, optionally filtered to a launch template.",
 	Long:  ``,
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.RangeArgs(1, 2), // nolint: mnd
 	Run: func(_ *cobra.Command, args []string) {
 		accountName := args[0]
 		omat := loadOmatConfig(accountName)
@@ -106,11 +106,30 @@ var hostsCmd = &cobra.Command{
 		details := awsutil.FindAndAssumeAdminRole(omat)
 
 		ec2Client := ec2.New(details.Session, details.Config)
+
+		var filters []*ec2.Filter
+
+		if len(args) == 2 { // nolint: mnd
+			template := resolveLaunchTemplate(ec2Client, args[1])
+			filters = append(filters, &ec2.Filter{
+				Name:   aws.String("tag:" + config.LTIDTag),
+				Values: []*string{template.LaunchTemplateId},
+			})
+		}
+
+		if hostsState != "" {
+			filters = append(filters, &ec2.Filter{
+				Name:   aws.String("instance-state-name"),
+				Values: []*string{aws.String(hostsState)},
+			})
+		}
+
 		nextToken := aws.String("")
 		hosts := []*ec2.Instance{}
 
 		for {
 			hostResp, err := ec2Client.DescribeInstances(&ec2.DescribeInstancesInput{
+				Filters:   filters,
 				NextToken: nextToken,
 			})
 			if err != nil {
@@ -132,7 +151,11 @@ var hostsCmd = &cobra.Command{
 	},
 }
 
+// nolint: gochecknoglobals
+var hostsState string
+
 // nolint: gochecknoinits
 func init() {
 	rootCmd.AddCommand(hostsCmd)
+	hostsCmd.Flags().StringVarP(&hostsState, "state", "", "", "Filter by instance state (e.g. running, stopped)")
 }

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -17,6 +17,40 @@ const (
 	LaunchWaitTimeout = 30
 )
 
+// resolveLaunchTemplate returns the single launch template whose name has the
+// given prefix. It prints the available templates and exits if zero or more than
+// one match, so callers can rely on getting exactly one template back.
+func resolveLaunchTemplate(ec2Client *ec2.EC2, namePrefix string) *ec2.LaunchTemplate {
+	templates, err := awsutil.FetchLaunchTemplates(ec2Client, nil)
+	if err != nil {
+		util.Fatal(1, err)
+	}
+
+	candidates := make([]*ec2.LaunchTemplate, 0)
+	for _, template := range templates {
+		if strings.HasPrefix(aws.StringValue(template.LaunchTemplateName), namePrefix) {
+			candidates = append(candidates, template)
+		}
+	}
+
+	switch {
+	case len(candidates) == 0:
+		fmt.Printf("Found the following launch templates, none of which match specified prefix:\n")
+		for _, template := range templates {
+			fmt.Printf("\t%s\n", aws.StringValue(template.LaunchTemplateName))
+		}
+		util.Fatalf(1, "No matching launch templates found.\n")
+	case len(candidates) > 1:
+		fmt.Printf("Found the following launch templates matching specified prefix:\n")
+		for _, candidate := range candidates {
+			fmt.Printf("\t%s\n", aws.StringValue(candidate.LaunchTemplateName))
+		}
+		util.Fatalf(1, "Multiple launch templates found.\n")
+	}
+
+	return candidates[0]
+}
+
 // nolint: gochecknoglobals,gomnd
 var launchCmd = &cobra.Command{
 	Use:   "launch account template-name keypair-name [subnet-id]",
@@ -51,32 +85,7 @@ will be used.`,
 			instanceType = aws.String(launchType)
 		}
 
-		templates, err := awsutil.FetchLaunchTemplates(ec2Client, nil)
-		if err != nil {
-			util.Fatal(1, err)
-		}
-		candidates := make([]string, 0)
-		for _, template := range templates {
-			templateName := aws.StringValue(template.LaunchTemplateName)
-			if strings.HasPrefix(templateName, namePrefix) {
-				candidates = append(candidates, templateName)
-			}
-		}
-
-		if len(candidates) == 0 {
-			fmt.Printf("Found the following launch templates, none of which match specified prefix:\n")
-			for _, template := range templates {
-				fmt.Printf("\t%s\n", aws.StringValue(template.LaunchTemplateName))
-			}
-			util.Fatalf(1, "No matching launch templates found.\n")
-		} else if len(candidates) > 1 {
-			fmt.Printf("Found the following launch templates matching specified prefix:\n")
-			for _, candidate := range candidates {
-				fmt.Printf("\t%s\n", candidate)
-			}
-			util.Fatalf(1, "Multiple launch templates found.\n")
-		}
-		name := candidates[0]
+		name := aws.StringValue(resolveLaunchTemplate(ec2Client, namePrefix).LaunchTemplateName)
 		fmt.Printf("Using launch template %s...\n", name)
 
 		input := ec2.RunInstancesInput{

--- a/config/consts.go
+++ b/config/consts.go
@@ -4,6 +4,7 @@ const (
 	AppTag       = "Application"
 	ASGTag       = "aws:autoscaling:groupName"
 	CommitTag    = "BuildCommit"
+	LTIDTag      = "aws:ec2launchtemplate:id"
 	LTVersionTag = "aws:ec2launchtemplate:version"
 	NameTag      = "Name"
 	ServiceTag   = "Service"


### PR DESCRIPTION
`omat hosts <account>` gains two optional filters:

- `[template-name]` — resolved the same way `launch` resolves it (prefix match on launch-template name → one template), then filters instances by the `aws:ec2launchtemplate:id` tag AWS auto-applies. So you see exactly the instances of the template `launch` would deploy, not whatever the `Service` tag happens to say.
- `--state` — maps to EC2's `instance-state-name` filter (e.g. `running`, `stopped`).

Both optional and independent. Example:

```
omat hosts workload-prod carrot-console --state running
```

Factored launch's resolution into `resolveLaunchTemplate` so both commands share it. Full prompt-by-prompt log is in the commit message.